### PR TITLE
Enable Rigidbody interpolation for smoother camera

### DIFF
--- a/Assets/Scripts/Player Movement/CharacterControl.cs
+++ b/Assets/Scripts/Player Movement/CharacterControl.cs
@@ -97,6 +97,7 @@ public class CharacterControl : MonoBehaviour
     void Start()
     {
         rb = GetComponent<Rigidbody2D>();
+        rb.interpolation = RigidbodyInterpolation2D.Interpolate;
         playercontrols = new PlayerControls();
         impulseSource = GetComponent<CinemachineImpulseSource>();
     }


### PR DESCRIPTION
## Summary
- Enable interpolation on the player's Rigidbody to provide smooth camera tracking without affecting movement mechanics

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_6892dff5f9bc8333a8cc6930df97e917