### PR TITLE
Implement omnidirectional melee swipe

### DIFF
--- a/Assets/Scenes/Melee Combat Tester.unity
+++ b/Assets/Scenes/Melee Combat Tester.unity
@@ -180,15 +180,15 @@ Camera:
   m_LensShift: {x: 0, y: 0}
   m_NormalizedViewPortRect:
     serializedVersion: 2
-    x: 0
+    x: 0.00234375
     y: 0
-    width: 1
+    width: 0.9953125
     height: 1
   near clip plane: 0.3
   far clip plane: 1000
   field of view: 60
   orthographic: 1
-  orthographic size: 11.25
+  orthographic size: 11.875
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -624,6 +624,9 @@ MonoBehaviour:
   attackMovementTime: 0.25
   meleeAttackDir: {x: 0, y: 0}
   raw: {x: 0, y: 0}
+  weaponPivot: {fileID: 0}
+  swipeReach: 1
+  cancelParentFlip: 1
 --- !u!1 &968232440
 GameObject:
   m_ObjectHideFlags: 0
@@ -1227,6 +1230,9 @@ MonoBehaviour:
   attackMovementTime: 0.25
   meleeAttackDir: {x: 0, y: 0}
   raw: {x: 0, y: 0}
+  weaponPivot: {fileID: 135976408}
+  swipeReach: 1
+  cancelParentFlip: 0
 --- !u!95 &1226843459
 Animator:
   serializedVersion: 7
@@ -1692,6 +1698,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1226843449}
     m_Modifications:
+    - target: {fileID: 3663729581385513653, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4160257479151078206, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
       propertyPath: m_BodyType
       value: 0
@@ -1714,11 +1724,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4607338527812533777, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
       propertyPath: m_Size.x
-      value: 3.17
+      value: 4.67
       objectReference: {fileID: 0}
     - target: {fileID: 4607338527812533777, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
       propertyPath: m_Size.y
-      value: 1.04
+      value: 3.22
+      objectReference: {fileID: 0}
+    - target: {fileID: 4607338527812533777, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4607338527812533777, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
       propertyPath: m_SortingLayer
@@ -1734,15 +1748,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4652559972507845044, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4801733738833317740, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4801733738833317740, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4801733738833317740, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4801733738833317740, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.18
+      value: 0.03
       objectReference: {fileID: 0}
     - target: {fileID: 4801733738833317740, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.18
+      value: -0.16
       objectReference: {fileID: 0}
     - target: {fileID: 4801733738833317740, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1791,6 +1817,10 @@ PrefabInstance:
     - target: {fileID: 8815412744864774530, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
       propertyPath: boxSize.y
       value: 1.06
+      objectReference: {fileID: 0}
+    - target: {fileID: 8815412744864774530, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8815412744864774530, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
       propertyPath: pogoForce
@@ -1842,9 +1872,137 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 4801733738833317740, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1362055173}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5f17cba79fd867848a45652618f6a0da, type: 3}
+--- !u!1 &1362055172
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1362055173}
+  - component: {fileID: 1362055174}
+  - component: {fileID: 1362055175}
+  m_Layer: 10
+  m_Name: MeleeChild
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1362055173
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1362055172}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3.13, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 135976408}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!70 &1362055174
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1362055172}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 4.52, y: 2.55}
+  m_Direction: 1
+--- !u!212 &1362055175
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1362055172}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -142383655
+  m_SortingLayer: 4
+  m_SortingOrder: 2
+  m_Sprite: {fileID: 8329702953330457827, guid: 488fa59e04abea347a89697dcac5d4df, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 4.67, y: 3.22}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &1421264536
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Melee Attack/MeleeAttackManager.cs
+++ b/Assets/Scripts/Melee Attack/MeleeAttackManager.cs
@@ -52,19 +52,21 @@ public class MeleeAttackManager : MonoBehaviour
 
     private void CheckInput() // Main method to handle melee input and execute corresponding attacks
     {
-        // Read raw stick input without Unity’s smoothing
+        // ------------------------------------------------------------------
+        // 1. Gather raw input so that we know which way the player is aiming.
+        // ------------------------------------------------------------------
 
         float x = Input.GetAxisRaw("Horizontal"); // Raw horizontal axis value (-1 to 1)
         float y = Input.GetAxisRaw("Vertical");    // Raw vertical axis value (-1 to 1)
 
-        raw = new Vector2(x, y);
+        raw = new Vector2(x, y);                    // Cache for use by other systems
 
         // Define a small threshold to ignore tiny stick movements (joystick drift)
         const float deadZone = 0.2f;
         // If the stick’s overall tilt is less than the dead zone...
         if (raw.magnitude < deadZone)
         {
-            meleeAttackDir = Vector2.zero; // ...treat it as “no direction”
+            meleeAttackDir = Vector2.zero;          // ...treat it as “no direction”
         }
         else
         {
@@ -72,8 +74,8 @@ public class MeleeAttackManager : MonoBehaviour
             const float cardinalThreshold = 2.3f;
             float ax = Mathf.Abs(raw.x), ay = Mathf.Abs(raw.y); // absolute X and Y for comparison
 
-            Vector2 dir; // will hold our snapped direction
-                         // If horizontal input dominates by our threshold...
+            Vector2 dir;                               // will hold our snapped direction
+                                                       // If horizontal input dominates by our threshold...
             if (ax > ay * cardinalThreshold)
                 dir = new Vector2(Mathf.Sign(raw.x), 0);       // ...snap to pure left/right
                                                                // Else if vertical input dominates...
@@ -83,75 +85,105 @@ public class MeleeAttackManager : MonoBehaviour
                 // Otherwise, treat it as a diagonal using the sign of each axis
                 dir = new Vector2(Mathf.Sign(raw.x), Mathf.Sign(raw.y));
 
-            meleeAttackDir = dir; // store the discrete direction (±1,0) or (±1,±1)
+            meleeAttackDir = dir;                      // store the discrete direction (±1,0) or (±1,±1)
         }
 
         // If the player didn’t actually press the attack button...
         if (!meleeAttackInput)
-            return;                        // exit early, no attack to perform
+            return;                                    // exit early, no attack to perform
 
-        meleeAttack = meleeAttackInput;    // copy the input flag for any other systems
+        meleeAttack = meleeAttackInput;                // copy the input flag for any other systems
 
+        // This bool tracks whether an attack animation was played at all.
+        bool performedAttack = false;
 
-        // Use the snapped direction to pick which attack animation to play
+        // -------------------------------------------------------------
+        // 2. Trigger the player’s swing animation based on the snapped
+        //    direction.  The weapon’s swipe animation is handled later
+        //    so that it can rotate freely.
+        // -------------------------------------------------------------
         switch (meleeAttackDir)
         {
             case var d when d == new Vector2(0, 1):   // straight up
-                anim.SetTrigger("UpwardMelee");          // trigger character animation
-                meleeAnimator.SetTrigger("UpwardMeleeSwipe"); // trigger swipe VFX
-                meleeAttackInput = false;                // clear the input flag
+                anim.SetTrigger("UpwardMelee");       // trigger character animation
                 TrySticky();
+                performedAttack = true;
                 break;
 
             case var d when d == new Vector2(0, -1)
                            && !characterControl.isGrounded:  // straight down in air
                 anim.SetTrigger("DownwardMelee");
-                meleeAnimator.SetTrigger("DownwardMeleeSwipe");
-                meleeAttackInput = false;
+                performedAttack = true;
                 break;
 
-            case var d when (d.y == 0): // forward on ground or no dir
+            case var d when (d.y == 0):              // forward on ground or no dir
                 anim.SetTrigger("ForwardMelee");
-                meleeAnimator.SetTrigger("ForwardMeleeSwipe");
-                meleeAttackInput = false;
                 TrySticky();
+                performedAttack = true;
                 break;
 
-            case var d when d == new Vector2(1, 1):   // up‐right diagonal
+            case var d when d == new Vector2(1, 1):   // up-right diagonal
                 anim.SetTrigger("UpwardDiagonalMelee");
-                meleeAnimator.SetTrigger("UpwardDiagonalMeleeSwipe");
-                meleeAttackInput = false;
                 TrySticky();
+                performedAttack = true;
                 break;
 
             case var d when d == new Vector2(1, -1)
-                           && !characterControl.isGrounded: // down‐right diagonal in air
+                           && !characterControl.isGrounded: // down-right diagonal in air
                 anim.SetTrigger("DownwardDiagonalMelee");
-                meleeAnimator.SetTrigger("DownwardDiagonalMeleeSwipe");
-                meleeAttackInput = false;
                 TrySticky();
+                performedAttack = true;
                 break;
 
-            case var d when d == new Vector2(-1, 1):   // up‐left diagonal
+            case var d when d == new Vector2(-1, 1):  // up-left diagonal
                 anim.SetTrigger("UpwardDiagonalMelee");
-                meleeAnimator.SetTrigger("UpwardDiagonalMeleeSwipe");
-                meleeAttackInput = false;
                 TrySticky();
+                performedAttack = true;
                 break;
 
             case var d when d == new Vector2(-1, -1)
-                           && !characterControl.isGrounded: // down‐left diagonal in air
+                           && !characterControl.isGrounded: // down-left diagonal in air
                 anim.SetTrigger("DownwardDiagonalMelee");
-                meleeAnimator.SetTrigger("DownwardDiagonalMeleeSwipe");
-                meleeAttackInput = false;
                 TrySticky();
+                performedAttack = true;
                 break;
 
             default:
-                TrySticky();
-                // Any other case (e.g. grounded down-diagonal) — do nothing
+                TrySticky();                          // grounded down-diagonal, do nothing
                 break;
         }
+
+        // -----------------------------------------------------------------
+        // 3. If an attack was performed, rotate the swipe to face the raw
+        //    input direction and trigger the omni-directional swipe effect.
+        // -----------------------------------------------------------------
+        if (performedAttack)
+        {
+            // Determine the direction the swipe should face.  If no stick
+            // input is given, default to the character’s facing direction.
+            Vector2 swipeDir = raw;
+            if (swipeDir == Vector2.zero)
+                swipeDir = characterControl.facingRight ? Vector2.right : Vector2.left;
+
+            // Grounded downward attacks are disallowed; force horizontal.
+            if (characterControl.isGrounded && swipeDir.y < 0)
+                swipeDir.y = 0;
+
+            PlayOmniSwipe(swipeDir);                  // rotate + trigger animation
+            meleeAttackInput = false;                 // clear the input flag
+        }
+    }
+
+    private void PlayOmniSwipe(Vector2 direction)
+    {
+        // Rotate the swipe animator so that its local X axis points along
+        // the desired direction.  The swipe animation itself faces right
+        // by default, so aligning transform.right works for any direction.
+        float angle = Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg;
+        meleeAnimator.transform.rotation = Quaternion.Euler(0f, 0f, angle);
+
+        // Trigger the universal swipe animation.
+        meleeAnimator.SetTrigger("OmniMeleeSwipe");
     }
 
 

--- a/Assets/Scripts/Melee Attack/OmniSwipeSetupInstructions.md
+++ b/Assets/Scripts/Melee Attack/OmniSwipeSetupInstructions.md
@@ -1,0 +1,24 @@
+# Omnidirectional Swipe Setup
+
+The code expects the melee weapon to use a **single** swipe animation that can be rotated to any direction.  Follow these steps in Unity to replace the old directional swipe animations.
+
+1. **Create the animation**
+   - Make a new animation clip called `OmniMeleeSwipe` based on the old forward swipe.
+   - Ensure the animation faces **right** at 0° rotation and includes the capsule collider enabling/disabling and the white flash/hit effects.
+   - If pogoing is required, add the existing `PerformPogo` animation event at the correct frame.
+
+2. **Animator controller**
+   - On the melee weapon's animator, remove the old directional swipe states or leave them unused.
+   - Add a trigger parameter named `OmniMeleeSwipe`.
+   - Create a state that plays the new `OmniMeleeSwipe` clip and transition to it from *Any State* when the trigger fires.  The state should automatically exit back to idle when the clip finishes.
+
+3. **Pivot / rotation**
+   - The melee weapon GameObject that holds the animator will be rotated by script.  Place the pivot so that rotating around Z points the swipe in the desired direction.
+   - The swipe should scale/position correctly when the object rotates (no directional offsets).
+
+4. **Testing**
+   - Verify that swinging with no directional input aims forward based on the player's facing.
+   - Moving the stick in any direction (except down while grounded) should rotate the swipe to match the stick direction.
+   - Downward attacks while in the air still trigger pogo and other effects.
+
+With the above steps complete the new omnidirectional system will function with the updated scripts.

--- a/Assets/Scripts/Melee Attack/OmniSwipeSetupInstructions.md.meta
+++ b/Assets/Scripts/Melee Attack/OmniSwipeSetupInstructions.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 50dcbaaed07986d4bab2428d44372984
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Characters/Audrey/Animations/Melee Weapon.controller
+++ b/Assets/Sprites/Characters/Audrey/Animations/Melee Weapon.controller
@@ -1,27 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1101 &-8805747351750142190
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions: []
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 2513709029988813466}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 1
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 2
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
 --- !u!1102 &-5189338819138314683
 AnimatorState:
   serializedVersion: 6
@@ -29,7 +7,7 @@ AnimatorState:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: ForwardMeleeSwipe
+  m_Name: OmniMeleeSwipe
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
@@ -49,55 +27,6 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1101 &-4362749551175427435
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions: []
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 2513709029988813466}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 1
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 2
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!1102 &-3022473280595977226
-AnimatorState:
-  serializedVersion: 6
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: DownwardMeleeSwipe
-  m_Speed: 1
-  m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: -4362749551175427435}
-  m_StateMachineBehaviours: []
-  m_Position: {x: 50, y: 50, z: 0}
-  m_IKOnFeet: 0
-  m_WriteDefaultValues: 1
-  m_Mirror: 0
-  m_SpeedParameterActive: 0
-  m_MirrorParameterActive: 0
-  m_CycleOffsetParameterActive: 0
-  m_TimeParameterActive: 0
-  m_Motion: {fileID: 7400000, guid: d4b1d4192391f394aaa0d58c733e5e09, type: 2}
-  m_Tag: 
-  m_SpeedParameter: 
-  m_MirrorParameter: 
-  m_CycleOffsetParameter: 
-  m_TimeParameter: 
 --- !u!1101 &-2514820128455437581
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -107,7 +36,7 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
-    m_ConditionEvent: ForwardMeleeSwipe
+    m_ConditionEvent: OmniMeleeSwipe
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -5189338819138314683}
@@ -123,55 +52,6 @@ AnimatorStateTransition:
   m_InterruptionSource: 2
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!1101 &-1491847049847829514
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions: []
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 2513709029988813466}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 1
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 2
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!1102 &-614720125299810263
-AnimatorState:
-  serializedVersion: 6
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UpwardDiagonalMeleeSwipe
-  m_Speed: 1
-  m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: 6857288800015999830}
-  m_StateMachineBehaviours: []
-  m_Position: {x: 50, y: 50, z: 0}
-  m_IKOnFeet: 0
-  m_WriteDefaultValues: 1
-  m_Mirror: 0
-  m_SpeedParameterActive: 0
-  m_MirrorParameterActive: 0
-  m_CycleOffsetParameterActive: 0
-  m_TimeParameterActive: 0
-  m_Motion: {fileID: 7400000, guid: 6ba74aeac8b23cb468631a3a1f2bd173, type: 2}
-  m_Tag: 
-  m_SpeedParameter: 
-  m_MirrorParameter: 
-  m_CycleOffsetParameter: 
-  m_TimeParameter: 
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -206,6 +86,12 @@ AnimatorController:
     m_DefaultBool: 0
     m_Controller: {fileID: 9100000}
   - m_Name: DownwardMeleeSwipe
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: OmniMeleeSwipe
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
@@ -257,11 +143,7 @@ AnimatorState:
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
-  - {fileID: 3080843703376049148}
-  - {fileID: 5083565801525923241}
   - {fileID: -2514820128455437581}
-  - {fileID: 5490173909454004549}
-  - {fileID: 6436598977652688965}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -277,182 +159,6 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1101 &3080843703376049148
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: UpwardMeleeSwipe
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 5956826418921930819}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 0.75
-  m_HasExitTime: 0
-  m_HasFixedDuration: 0
-  m_InterruptionSource: 2
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!1101 &5083565801525923241
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: UpwardDiagonalMeleeSwipe
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: -614720125299810263}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 0.75
-  m_HasExitTime: 0
-  m_HasFixedDuration: 0
-  m_InterruptionSource: 2
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!1101 &5490173909454004549
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: DownwardDiagonalMeleeSwipe
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 5937410547893821226}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 0.75
-  m_HasExitTime: 0
-  m_HasFixedDuration: 0
-  m_InterruptionSource: 2
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!1102 &5937410547893821226
-AnimatorState:
-  serializedVersion: 6
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: DownwardDiagonalMeleeSwipe
-  m_Speed: 1
-  m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: -1491847049847829514}
-  m_StateMachineBehaviours: []
-  m_Position: {x: 50, y: 50, z: 0}
-  m_IKOnFeet: 0
-  m_WriteDefaultValues: 1
-  m_Mirror: 0
-  m_SpeedParameterActive: 0
-  m_MirrorParameterActive: 0
-  m_CycleOffsetParameterActive: 0
-  m_TimeParameterActive: 0
-  m_Motion: {fileID: 7400000, guid: bdb30cecdf62b8c489c9016c8f425a47, type: 2}
-  m_Tag: 
-  m_SpeedParameter: 
-  m_MirrorParameter: 
-  m_CycleOffsetParameter: 
-  m_TimeParameter: 
---- !u!1102 &5956826418921930819
-AnimatorState:
-  serializedVersion: 6
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UpwardMeleeSwipe
-  m_Speed: 1
-  m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: -8805747351750142190}
-  m_StateMachineBehaviours: []
-  m_Position: {x: 50, y: 50, z: 0}
-  m_IKOnFeet: 0
-  m_WriteDefaultValues: 1
-  m_Mirror: 0
-  m_SpeedParameterActive: 0
-  m_MirrorParameterActive: 0
-  m_CycleOffsetParameterActive: 0
-  m_TimeParameterActive: 0
-  m_Motion: {fileID: 7400000, guid: 9ba00b18fd27d2248ae4d640e4c442ea, type: 2}
-  m_Tag: 
-  m_SpeedParameter: 
-  m_MirrorParameter: 
-  m_CycleOffsetParameter: 
-  m_TimeParameter: 
---- !u!1101 &6436598977652688965
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: DownwardMeleeSwipe
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: -3022473280595977226}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 0.75
-  m_HasExitTime: 0
-  m_HasFixedDuration: 0
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!1101 &6857288800015999830
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions: []
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 2513709029988813466}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 1
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 2
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
 --- !u!1107 &8475929318190326028
 AnimatorStateMachine:
   serializedVersion: 6
@@ -465,18 +171,6 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: -5189338819138314683}
     m_Position: {x: -110, y: 250, z: 0}
-  - serializedVersion: 1
-    m_State: {fileID: 5956826418921930819}
-    m_Position: {x: -410, y: 120, z: 0}
-  - serializedVersion: 1
-    m_State: {fileID: -3022473280595977226}
-    m_Position: {x: -420, y: 380, z: 0}
-  - serializedVersion: 1
-    m_State: {fileID: -614720125299810263}
-    m_Position: {x: -120, y: 120, z: 0}
-  - serializedVersion: 1
-    m_State: {fileID: 5937410547893821226}
-    m_Position: {x: -110, y: 380, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 2513709029988813466}
     m_Position: {x: -420, y: 250, z: 0}

--- a/Assets/Sprites/Characters/Audrey/Animations/OmniMeleeSwipe.anim
+++ b/Assets/Sprites/Characters/Audrey/Animations/OmniMeleeSwipe.anim
@@ -6,7 +6,7 @@ AnimationClip:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: ForwardMeleeSwipe
+  m_Name: OmniMeleeSwipe
   serializedVersion: 7
   m_Legacy: 0
   m_Compressed: 0
@@ -20,7 +20,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: {x: 0, y: 0, z: 0}
+        value: {x: 1.97, y: -0.14, z: -0.0051235366}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -29,7 +29,7 @@ AnimationClip:
         outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
       - serializedVersion: 3
         time: 0.016666668
-        value: {x: 0, y: 0, z: 0}
+        value: {x: 1.97, y: -0.14, z: -0.0051235366}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -38,7 +38,7 @@ AnimationClip:
         outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
       - serializedVersion: 3
         time: 0.16666667
-        value: {x: 0, y: 0, z: 0}
+        value: {x: 1.97, y: -0.14, z: -0.0051235366}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -47,7 +47,7 @@ AnimationClip:
         outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
       - serializedVersion: 3
         time: 0.18333334
-        value: {x: 0, y: 0, z: 0}
+        value: {x: 1.97, y: -0.14, z: -0.0051235366}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -56,7 +56,7 @@ AnimationClip:
         outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
       - serializedVersion: 3
         time: 0.25
-        value: {x: 0, y: 0, z: 0}
+        value: {x: 1.97, y: -0.14, z: -0.0051235366}
         inSlope: {x: 0, y: 0, z: 0}
         outSlope: {x: 0, y: 0, z: 0}
         tangentMode: 0
@@ -127,7 +127,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0
+        value: 1.97
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -145,15 +145,6 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.083333336
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.1
         value: 0
         inSlope: 0
         outSlope: 0
@@ -202,7 +193,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0
+        value: -0.14
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -277,7 +268,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.016666668
-        value: 0
+        value: 4.86
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -286,7 +277,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.083333336
-        value: 0
+        value: 4.86
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -352,7 +343,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.016666668
-        value: 0
+        value: 3.18
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -361,7 +352,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.083333336
-        value: 0
+        value: 3.18
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -442,24 +433,6 @@ AnimationClip:
       isSerializeReferenceCurve: 0
     - serializedVersion: 2
       path: 0
-      attribute: 0
-      script: {fileID: 0}
-      typeID: 212
-      customType: 23
-      isPPtrCurve: 1
-      isIntCurve: 0
-      isSerializeReferenceCurve: 0
-    - serializedVersion: 2
-      path: 0
-      attribute: 1
-      script: {fileID: 0}
-      typeID: 4
-      customType: 0
-      isPPtrCurve: 0
-      isIntCurve: 0
-      isSerializeReferenceCurve: 0
-    - serializedVersion: 2
-      path: 0
       attribute: 413499720
       script: {fileID: 0}
       typeID: 70
@@ -494,6 +467,24 @@ AnimationClip:
       isPPtrCurve: 0
       isIntCurve: 0
       isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 0
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
     pptrCurveMapping:
     - {fileID: 8329702953330457827, guid: 488fa59e04abea347a89697dcac5d4df, type: 3}
     - {fileID: 3566956744491535144, guid: ac7475fc0b48c7247a15c9b1b8dfea44, type: 3}
@@ -507,7 +498,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 0
+    m_LoopTime: 1
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0
@@ -524,7 +515,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0
+        value: 1.97
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -533,25 +524,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.016666668
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.083333336
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.1
-        value: 0
+        value: 1.97
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -560,7 +533,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.16666667
-        value: 0
+        value: 1.97
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -569,7 +542,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.18333334
-        value: 0
+        value: 1.97
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -578,7 +551,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.25
-        value: 0
+        value: 1.97
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -588,9 +561,9 @@ AnimationClip:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-    attribute: m_Offset.x
+    attribute: m_LocalPosition.x
     path: 
-    classID: 70
+    classID: 4
     script: {fileID: 0}
     flags: 0
   - serializedVersion: 2
@@ -599,7 +572,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0
+        value: -0.14
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -608,16 +581,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.016666668
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.083333336
-        value: 0
+        value: -0.14
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -626,7 +590,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.16666667
-        value: 0
+        value: -0.14
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -635,7 +599,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.18333334
-        value: 0
+        value: -0.14
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -644,7 +608,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.25
-        value: 0
+        value: -0.14
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -654,9 +618,9 @@ AnimationClip:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-    attribute: m_Offset.y
+    attribute: m_LocalPosition.y
     path: 
-    classID: 70
+    classID: 4
     script: {fileID: 0}
     flags: 0
   - serializedVersion: 2
@@ -665,34 +629,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.016666668
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.083333336
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.1
-        value: 0
+        value: -0.0051235366
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -701,7 +638,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.16666667
-        value: 0
+        value: -0.0051235366
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -710,7 +647,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.18333334
-        value: 0
+        value: -0.0051235366
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -719,7 +656,7 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.25
-        value: 0
+        value: -0.0051235366
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -729,84 +666,9 @@ AnimationClip:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-    attribute: m_Size.x
+    attribute: m_LocalPosition.z
     path: 
-    classID: 70
-    script: {fileID: 0}
-    flags: 0
-  - serializedVersion: 2
-    curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.016666668
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.083333336
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.1
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.16666667
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.18333334
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.25
-        value: 0
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_Size.y
-    path: 
-    classID: 70
+    classID: 4
     script: {fileID: 0}
     flags: 0
   - serializedVersion: 2
@@ -986,7 +848,7 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 0
+        value: 1.97
         inSlope: 0
         outSlope: 0
         tangentMode: 136
@@ -995,6 +857,15 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.016666668
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.083333336
         value: 0
         inSlope: 0
         outSlope: 0
@@ -1032,9 +903,75 @@ AnimationClip:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-    attribute: m_LocalPosition.x
+    attribute: m_Offset.x
     path: 
-    classID: 4
+    classID: 70
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: -0.14
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.016666668
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.083333336
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.16666667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.18333334
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.25
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Offset.y
+    path: 
+    classID: 70
     script: {fileID: 0}
     flags: 0
   - serializedVersion: 2
@@ -1052,6 +989,24 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.016666668
+        value: 4.86
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.083333336
+        value: 4.86
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.1
         value: 0
         inSlope: 0
         outSlope: 0
@@ -1089,9 +1044,9 @@ AnimationClip:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-    attribute: m_LocalPosition.y
+    attribute: m_Size.x
     path: 
-    classID: 4
+    classID: 70
     script: {fileID: 0}
     flags: 0
   - serializedVersion: 2
@@ -1109,6 +1064,24 @@ AnimationClip:
         outWeight: 0.33333334
       - serializedVersion: 3
         time: 0.016666668
+        value: 3.18
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.083333336
+        value: 3.18
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.1
         value: 0
         inSlope: 0
         outSlope: 0
@@ -1146,9 +1119,9 @@ AnimationClip:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-    attribute: m_LocalPosition.z
+    attribute: m_Size.y
     path: 
-    classID: 4
+    classID: 70
     script: {fileID: 0}
     flags: 0
   m_EulerEditorCurves: []

--- a/Assets/Sprites/Characters/Audrey/Animations/OmniMeleeSwipe.anim.meta
+++ b/Assets/Sprites/Characters/Audrey/Animations/OmniMeleeSwipe.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 92bfc8f09520e074f89d8fd0395748ba
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Refactor melee attack manager to trigger a single swipe animation that rotates toward stick input
- Keep player swing animations for 8 directions while swiping in any direction except downward on ground
- Document Unity setup steps for new omni swipe animation

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893cf5c856083338cf7b03782f21f63